### PR TITLE
linux: Refresh the menu when it's set so dbus ever finds out

### DIFF
--- a/v3/pkg/application/systemtray_linux.go
+++ b/v3/pkg/application/systemtray_linux.go
@@ -222,6 +222,7 @@ func (s *linuxSystemTray) setMenu(menu *Menu) {
 	menu.processRadioGroups()
 	s.processMenu(menu, 0)
 	s.menu = menu
+	s.refresh()
 }
 
 func (s *linuxSystemTray) positionWindow(window Window, offset int) error {


### PR DESCRIPTION
This makes it actually work on my machine. I have no idea why.